### PR TITLE
added timestamps argument to logs get method

### DIFF
--- a/lib/logs.js
+++ b/lib/logs.js
@@ -1,8 +1,8 @@
 const Client = require('./client-base');
 
 class Logs extends Client {
-    async get({ podName, containerName, tailLines }) {
-        return this._prefix.namespaces(this._namespace).pods(podName).log.get({ qs: { container: containerName, tailLines } });
+    async get({ podName, containerName, tailLines, timestamps = false }) {
+        return this._prefix.namespaces(this._namespace).pods(podName).log.get({ qs: { container: containerName, tailLines, timestamps } });
     }
 }
 


### PR DESCRIPTION
Added timestamps argument to logs retrieval when fetching logs from k8s.
Related issue: https://github.com/kube-HPC/hkube/issues/1821

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/kubernetes-client.hkube/37)
<!-- Reviewable:end -->
