### PR TITLE
client now support CRDs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@ const ResourceQuotas = require('./resourceQuotas');
 const Secrets = require('./secrets');
 const SideCars = require('./sidecars');
 const PVC = require('./pvc');
+const CRDs = require('./crds');
 
 class Client {
     async init(options) {
@@ -39,6 +40,7 @@ class Client {
         this.secrets = new Secrets(client, namespace, this.kubeVersion);
         this.sidecars = new SideCars(client, namespace, this.kubeVersion, this.configMaps);
         this.pvc = new PVC(client, namespace, this.kubeVersion);
+        this.crds = new CRDs(client, namespace, this.kubeVersion);
     }
 }
 

--- a/lib/crds.js
+++ b/lib/crds.js
@@ -1,0 +1,48 @@
+const Client = require('./client-base');
+
+/**
+ * Client for interacting with arbitrary Custom Resource Definitions (CRDs).
+ * Allows fetching individual or all resources by manually constructing the API path.
+ */
+class CRDs extends Client {
+    /**
+     * Fetches a single custom resource or a list of custom resources.
+     *
+     * @param {Object} params - Parameters for the request.
+     * @param {string} params.group - API group of the CRD.
+     * @param {string} params.version - API version of the CRD.
+     * @param {string} params.resource - Resource type (e.g., 'queues').
+     * @param {string} [params.name] - Optional resource name for fetching a specific resource.
+     * @param {string} [params.labelSelector] - Optional label selector for filtering.
+     * @returns {Promise<Object>} The API response containing the requested resource(s).
+     */
+    async get({ name, group, version, resource, labelSelector } = {}) {
+        const basePath = name
+            ? `/apis/${group}/${version}/${resource}/${name}`
+            : `/apis/${group}/${version}/${resource}`;
+
+        const qs = labelSelector ? { labelSelector } : undefined;
+
+        return this._client.backend.http({
+            method: 'GET',
+            pathname: basePath,
+            qs
+        });
+    }
+
+    /**
+     * Fetches all custom resources of the specified type.
+     *
+     * @param {Object} params - Parameters for the request.
+     * @param {string} params.group - API group of the CRD.
+     * @param {string} params.version - API version of the CRD.
+     * @param {string} params.resource - Resource type (e.g., 'queues').
+     * @param {string} [params.labelSelector] - Optional label selector for filtering.
+     * @returns {Promise<Object>} The API response containing the list of resources.
+     */
+    all(params = {}) {
+        return this.get(params);
+    }
+}
+
+module.exports = CRDs;


### PR DESCRIPTION
added support for CRDs getters.
Related issue - https://github.com/kube-HPC/hkube/issues/2173
(used in task executor PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/kubernetes-client.hkube/38)
<!-- Reviewable:end -->
